### PR TITLE
Pin `pytest-cov` version to report coverage properly.

### DIFF
--- a/.github/workflows/continuous-integration-quality-unit-tests.yml
+++ b/.github/workflows/continuous-integration-quality-unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
       - name: Install Package Dependencies
         run: |
-          uv sync --all-extras --no-dev
+          uv sync --all-extras
         shell: bash
       - name: Pre-Commit (All Files)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ uv.lock
 .jj/
 
 # Common Directories
+.claude/
 .fleet/
 .idea/
 .ipynb_checkpoints/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev-dependencies = [
     "pre-commit",
     "pyright",
     "pytest",
-    "pytest-cov",
+    "pytest-cov<7.0.0",
     "pytest-xdist",
     "toml",
     "twine",


### PR DESCRIPTION
# Summary

Pin `pytest-cov<7.0.0` to resolve coverage reporting issue. `pytest-cov` 7.0.0 removed automatic subprocess coverage measurement, causing coverage to drop from 99% to 77% on the `colour` repository despite all tests passing.

Changes:
- Pin `pytest-cov<7.0.0` in `pyproject.toml`
- Update CI workflow: `uv sync --all-extras` instead of `--no-dev`

# Preflight

**Code Style and Quality**

- [x] Unit tests have been implemented and passed.
- [x] Pyright static checking has been run and passed.
- [x] Pre-commit hooks have been run and passed.

**Documentation**

- [N/A] New features are documented along with examples if relevant.
- [N/A] The documentation is [Sphinx](https://www.sphinx-doc.org/en/master/) and [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) compliant.